### PR TITLE
修复ios 11以下，设置baritems时，偏移位置不对的问题

### DIFF
--- a/UINavigation-SXFixSpace/UINavigationItem+SXFixSpace.m
+++ b/UINavigation-SXFixSpace/UINavigationItem+SXFixSpace.m
@@ -47,7 +47,7 @@
 }
 
 -(void)sx_setLeftBarButtonItems:(NSArray<UIBarButtonItem *> *)leftBarButtonItems {
-    if (leftBarButtonItems.count) {
+    if (leftBarButtonItems.count  && sx_deviceVersion >= 11) {
         NSMutableArray *items = [NSMutableArray arrayWithObject:[self fixedSpaceWithWidth:[UINavigationConfig shared].sx_defaultFixSpace-20]];//可修正iOS11之前的偏移
         [items addObjectsFromArray:leftBarButtonItems];
         [self sx_setLeftBarButtonItems:items];
@@ -69,7 +69,7 @@
 }
 
 -(void)sx_setRightBarButtonItems:(NSArray<UIBarButtonItem *> *)rightBarButtonItems{
-    if (rightBarButtonItems.count) {
+    if (rightBarButtonItems.count && sx_deviceVersion >= 11) {
         NSMutableArray *items = [NSMutableArray arrayWithObject:[self fixedSpaceWithWidth:[UINavigationConfig shared].sx_defaultFixSpace-20]];//可修正iOS11之前的偏移
         [items addObjectsFromArray:rightBarButtonItems];
         [self sx_setRightBarButtonItems:items];


### PR DESCRIPTION
修复ios 11以下，设置baritems时，偏移位置不对的问题。否则iOS11以下，项目中引入了此类目后，即使在逻辑层判断了iOS11系统，设置disable，在设置itms场景时候，仍会造成偏移位置不对。